### PR TITLE
Halves brute damage from punching, adds stamina damage

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -158,7 +158,9 @@
 
 				visible_message("<span class='danger'>[M] [pick(attack.attack_verb)]ed [src]!</span>")
 
-				apply_damage(damage, BRUTE, affecting, armor_block, sharp=attack.sharp, edge=attack.edge) //moving this back here means Armalis are going to knock you down  70% of the time, but they're pure adminbus anyway.
+				var/brutedam = round(damage/2)//2 times less than stamina damage; rounded down to the nearest 1
+				apply_damage(brutedam, BRUTE, affecting, armor_block, sharp=attack.sharp, edge=attack.edge) //moving this back here means Armalis are going to knock you down  70% of the time, but they're pure adminbus anyway.
+				apply_damage(damage, STAMINA, affecting, armor_block)
 				if((stat != DEAD) && damage >= M.species.punchstunthreshold)
 					visible_message("<span class='danger'>[M] has weakened [src]!</span>", \
 									"<span class='userdanger'>[M] has weakened [src]!</span>")


### PR DESCRIPTION
:cl: FlattestGuitar
tweak: punches now deal less brute and more stamina damage
/:cl:

Each unarmed claw or punch will now deal as much stamina damage as it used to do brute, as well as will deal only half of the brute damage it used to, rounded down.

Discuss.